### PR TITLE
feat: support dynamic Thunderstore profile selection in build scripts

### DIFF
--- a/GungeonTogether/build.ps1
+++ b/GungeonTogether/build.ps1
@@ -6,6 +6,7 @@ param(
 
 $Configuration = if ($Release) { "Release" } else { "Debug" }
 $PluginsPath = "$GamePath\BepInEx\plugins"
+$BepInExCorePath = ""
 
 # Check if we are using the gale mod manager
 $HarmonyDLLPath = "$env:APPDATA\com.kesomannen.gale\enter-the-gungeon\profiles\Default\BepInEx\"
@@ -15,11 +16,55 @@ if (Test-Path -Path (Join-Path $HarmonyDLLPath $HarmonyDLL)) {
     $PluginsPath = Join-Path $HarmonyDLLPath "plugins"
 }
 
-# check if we are using r2Modman (check appdata for r2Modman)
+# Check if we are using r2Modman (check appdata for r2Modman)
 $r2ModmanPath = "$env:APPDATA\r2modmanPlus-local\ETG\profiles\a\BepInEx\plugins"
 if (Test-Path -Path $r2ModmanPath) {
     Write-Host "r2Modman found, using new mod path: $r2ModmanPath" -ForegroundColor Green
     $PluginsPath = $r2ModmanPath
+}
+
+# Check if we are using Thunderstore Mod Manager (prompt user to select profile)
+$ThunderstoreDataPath = "$env:APPDATA\Thunderstore Mod Manager\DataFolder\ETG\profiles"
+if (Test-Path -Path $ThunderstoreDataPath) {
+    $AvailableProfiles = Get-ChildItem -Path $ThunderstoreDataPath -Directory
+    
+    if ($AvailableProfiles.Count -gt 0) {
+        $ActiveProfile = $null
+
+        # One profile: auto select
+        if ($AvailableProfiles.Count -eq 1) {
+            $ActiveProfile = $AvailableProfiles[0].FullName
+            Write-Host "Thunderstore Mod Manager profile detected: $($AvailableProfiles[0].Name)" -ForegroundColor Green
+        }
+        # Selection prompt
+        else {
+            Write-Host "`n--- Thunderstore Profiles Detected ---" -ForegroundColor Cyan
+            for ($i = 0; $i -lt $AvailableProfiles.Count; $i++) {
+                Write-Host "[$i] $($AvailableProfiles[$i].Name)" -ForegroundColor Yellow
+            }
+            
+            $Selection = -1
+            while ($Selection -lt 0 -or $Selection -ge $AvailableProfiles.Count) {
+                $UserChoice = Read-Host "Select a profile index to deploy to (Default is 0)"
+                if ([string]::IsNullOrWhiteSpace($UserChoice)) { 
+                    $Selection = 0 
+                } else {
+                    [int]::TryParse($UserChoice, [ref]$Selection) | Out-Null
+                }
+            }
+            $ActiveProfile = $AvailableProfiles[$Selection].FullName
+            Write-Host "Selected profile: $($AvailableProfiles[$Selection].Name)" -ForegroundColor Green
+        }
+        
+        $PluginsPath = Join-Path $ActiveProfile "BepInEx\plugins"
+        $BepInExCorePath = Join-Path $ActiveProfile "BepInEx\core"
+        
+        # Create the plugins folder if not present
+        if (-not (Test-Path -Path $PluginsPath)) {
+            Write-Host "Plugins folder missing. Creating: $PluginsPath" -ForegroundColor Yellow
+            New-Item -ItemType Directory -Path $PluginsPath -Force | Out-Null
+        }
+    }
 }
 
 Write-Host "Building GungeonTogether ($Configuration)..." -ForegroundColor Green
@@ -28,7 +73,7 @@ Write-Host "Building GungeonTogether ($Configuration)..." -ForegroundColor Green
 $SetupScript = Join-Path $PSScriptRoot "setup-libs.ps1"
 if (Test-Path $SetupScript) {
     Write-Host "Preparing Libs/ from game install..." -ForegroundColor Yellow
-    & $SetupScript -GamePath $GamePath
+    & $SetupScript -GamePath $GamePath -BepInExCorePath $BepInExCorePath
 }
 
 # Build the project

--- a/GungeonTogether/setup-libs.ps1
+++ b/GungeonTogether/setup-libs.ps1
@@ -1,5 +1,6 @@
 param(
-    [string]$GamePath = "C:\Program Files (x86)\Steam\steamapps\common\Enter the Gungeon"
+    [string]$GamePath = "C:\Program Files (x86)\Steam\steamapps\common\Enter the Gungeon",
+    [string]$BepInExCorePath = ""
 )
 
 $ErrorActionPreference = "Stop"
@@ -20,11 +21,20 @@ $libs = Join-Path $projectRoot "Libs"
 New-Item -ItemType Directory -Force -Path $libs | Out-Null
 
 $managed = Resolve-ManagedPath $GamePath
-$bepCore = Join-Path $GamePath "BepInEx\core"
 
-Write-Host "GamePath:   $GamePath" -ForegroundColor Cyan
-Write-Host "Managed:    $managed" -ForegroundColor Cyan
-Write-Host "BepInExCore:$bepCore" -ForegroundColor Cyan
+# Fallback behavior: if no explicit BepInEx path was passed, construct the standard Steam path
+if ([string]::IsNullOrEmpty($BepInExCorePath)) {
+    $bepCore = Join-Path $GamePath "BepInEx\core"
+    $bepRootSearchPath = Join-Path $GamePath "BepInEx"
+} else {
+    $bepCore = $BepInExCorePath
+    # For optional plugins like MTG/Json, search the parent profile directory instead of Steam's BepInEx
+    $bepRootSearchPath = Split-Path -Parent $bepCore
+}
+
+Write-Host "GamePath:    $GamePath" -ForegroundColor Cyan
+Write-Host "Managed:     $managed" -ForegroundColor Cyan
+Write-Host "BepInExCore: $bepCore" -ForegroundColor Cyan
 
 function Copy-IfExists([string]$from, [string]$toName) {
     if (Test-Path $from) {
@@ -53,8 +63,8 @@ Copy-IfExists (Join-Path $managed "UnityEngine.UIModule.dll") "UnityEngine.UIMod
 Copy-IfExists (Join-Path $managed "UnityEngine.UI.dll") "UnityEngine.UI.dll"
 
 # Optional: ModTheGungeonAPI + Newtonsoft.Json (best-effort search)
-$mtg = Get-ChildItem -Path (Join-Path $GamePath "BepInEx") -Filter "ModTheGungeonAPI.dll" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+$mtg = Get-ChildItem -Path $bepRootSearchPath -Filter "ModTheGungeonAPI.dll" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
 if ($mtg) { Copy-Item $mtg.FullName (Join-Path $libs "ModTheGungeonAPI.dll") -Force; Write-Host "Copied ModTheGungeonAPI.dll" -ForegroundColor Green }
 
-$json = Get-ChildItem -Path (Join-Path $GamePath "BepInEx") -Filter "Newtonsoft.Json.dll" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+$json = Get-ChildItem -Path $bepRootSearchPath -Filter "Newtonsoft.Json.dll" -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
 if ($json) { Copy-Item $json.FullName (Join-Path $libs "Newtonsoft.Json.dll") -Force; Write-Host "Copied Newtonsoft.Json.dll" -ForegroundColor Green }


### PR DESCRIPTION
## Proposal
Add Thunderstore Mod Manager support in the installation script

## Changes
* Automatically detects Thunderstore Mod Manager installation paths.
* Prompts the user to select an active profile if multiple exist.
* Ensures BepInEx/plugins folder structure is safely generated for empty profiles where it may not be present.
* Dynamically passes the profile's BepInEx core path to setup-libs.ps1 to resolve dependencies correctly.