### PR TITLE
Handle ConnectionRejected so rejected clients stop retrying

### DIFF
--- a/GungeonTogether/Networking/ClientController.cs
+++ b/GungeonTogether/Networking/ClientController.cs
@@ -79,6 +79,19 @@ namespace GungeonTogether.Networking
             Debug.Log($"[Client] Connection accepted by host {senderId}.");
         }
 
+        public void HandleConnectionRejected(ulong senderId, ConnectionRejectedPacket packet)
+        {
+            if (senderId != _hostId) return;
+
+            // The host explicitly turned us away - stop hammering it with retries.
+            // Without this the connect loop in Update() re-sends ConnectionRequest
+            // every ConnectRetryInterval forever, since _connectPending is otherwise
+            // only cleared on ConnectionAccepted.
+            _connectPending = false;
+            IsConnected = false;
+            Debug.LogWarning($"[Client] Connection rejected by host {senderId} (host protocol={packet.ProtocolVersion}, local={NetworkManager.ProtocolVersion}). Halting connection attempts.");
+        }
+
         public void Shutdown()
         {
             Disconnect();

--- a/GungeonTogether/Networking/NetworkManager.cs
+++ b/GungeonTogether/Networking/NetworkManager.cs
@@ -145,7 +145,13 @@ namespace GungeonTogether.Networking
                         Client.HandleConnectionAccepted(senderId, (ConnectionAcceptedPacket)packet);
                     }
                     break;
-                
+                case PacketType.ConnectionRejected:
+                    if (IsClient)
+                    {
+                        Client.HandleConnectionRejected(senderId, (ConnectionRejectedPacket)packet);
+                    }
+                    break;
+
                 case PacketType.PlayerPosition:
                     var posPacket = (PlayerPositionPacket)packet;
                     if (IsClient && posPacket.PlayerId != SteamReflectionHelper.GetLocalSteamId())


### PR DESCRIPTION
Hey! Loving the project — was reading through the netcode and spotted a concrete handshake bug, so figured a small PR was easier than an issue. Totally aware it's early WIP, so no pressure to take this as-is. 🙂

### The bug
`ConnectionRejected` is never routed anywhere in `NetworkManager.ProcessPacket`. The host *does* send `ConnectionRejectedPacket` on a protocol-version mismatch (`HostController.cs:98-104`), but on the client side:

- the connect loop in `ClientController.Update()` re-sends `ConnectionRequest` every `ConnectRetryInterval` while `_connectPending` is true, and
- `_connectPending` is only ever cleared in `HandleConnectionAccepted`.

So a client the host rejects never learns it was turned away and **keeps hammering the host with connection requests forever**.

### The fix
- Route `ConnectionRejected` to the client in `ProcessPacket` (mirrors the existing `ConnectionAccepted` case).
- Add `ClientController.HandleConnectionRejected`, which clears `_connectPending` to stop the retry loop and logs the reason (host vs. local protocol version).

Two files, +20/-1, no behavior change on the happy path.

### Note
I couldn't compile locally since the build needs the game/BepInEx DLLs in `Libs/`, but the change is tiny and follows the existing `HandleConnectionAccepted` pattern — worth a quick local build on your end before merging.

### A few other things I noticed while reading (not in this PR, happy to follow up)
- Enemy/room handlers (`EnemySpawn`/`EnemyState`/`EnemyDeath`/`RoomChange`) run regardless of `IsHost`/`IsClient`, and `EnemySpawn` does `Resources.Load` on an unvalidated network string.
- `SteamP2PManager.ReadPackets` has a `catch (Exception) { }` that swallows every error silently.
- `HostController.Shutdown` has an empty `foreach` where the disconnect broadcast was meant to go, so clients aren't told the host left.
- Minor: `SteamP2PManager.cs:328` logs `msgSize` before it's read from `availArgs[0]` (always prints "size 0"); duplicate `"Steamworks.P2PSessionRequest_t"` entry at `:208`/`:210`.

Nice work on the packet architecture overall!

🤖 Generated with [Claude Code](https://claude.com/claude-code)
